### PR TITLE
Flatten AccountAuthorization

### DIFF
--- a/src/admin.rs
+++ b/src/admin.rs
@@ -30,10 +30,10 @@ pub fn to_administrator_authorization(e: &Env, auth: Authorization) -> KeyedAuth
                 signature,
             })
         }
-        (Identifier::Account(admin_id), Authorization::Account(aa)) => {
+        (Identifier::Account(admin_id), Authorization::Account(signatures)) => {
             KeyedAuthorization::Account(KeyedAccountAuthorization {
                 public_key: admin_id,
-                auth: aa,
+                signatures,
             })
         }
         _ => panic!("unknown identifier type"),

--- a/src/cryptography.rs
+++ b/src/cryptography.rs
@@ -52,7 +52,7 @@ fn check_account_auth(
     let threshold = acc.medium_threshold();
     let mut weight = 0u32;
 
-    let sigs = &auth.auth.signatures;
+    let sigs = &auth.signatures;
     let mut prev_pk: Option<U256> = None;
     for sig in sigs.iter().map(Result::unwrap) {
         // Cannot take multiple signatures from the same key

--- a/src/public_types.rs
+++ b/src/public_types.rs
@@ -17,17 +17,13 @@ pub struct KeyedEd25519Authorization {
     pub signature: U512,
 }
 
-#[derive(Clone)]
-#[contracttype]
-pub struct AccountAuthorization {
-    pub signatures: Vec<KeyedEd25519Signature>,
-}
+pub type AccountAuthorization = Vec<KeyedEd25519Signature>;
 
 #[derive(Clone)]
 #[contracttype]
 pub struct KeyedAccountAuthorization {
     pub public_key: U256,
-    pub auth: AccountAuthorization,
+    pub signatures: AccountAuthorization,
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
### What

`AccountAuthorization` was a single-field `struct` for no reason after #20.

### Why

General tidying and simplicity.

### Known limitations

None