### PR TITLE
Remove KeyedEd25519Authorization because it is the same as other type

### DIFF
--- a/src/admin.rs
+++ b/src/admin.rs
@@ -1,6 +1,5 @@
 use crate::public_types::{
-    Authorization, Identifier, KeyedAccountAuthorization, KeyedAuthorization,
-    KeyedEd25519Authorization,
+    Authorization, Identifier, KeyedAccountAuthorization, KeyedAuthorization, KeyedEd25519Signature,
 };
 use crate::storage_types::DataKey;
 use soroban_sdk::Env;
@@ -25,7 +24,7 @@ pub fn to_administrator_authorization(e: &Env, auth: Authorization) -> KeyedAuth
             KeyedAuthorization::Contract
         }
         (Identifier::Ed25519(admin_id), Authorization::Ed25519(signature)) => {
-            KeyedAuthorization::Ed25519(KeyedEd25519Authorization {
+            KeyedAuthorization::Ed25519(KeyedEd25519Signature {
                 public_key: admin_id,
                 signature,
             })

--- a/src/cryptography.rs
+++ b/src/cryptography.rs
@@ -1,6 +1,6 @@
 use crate::nonce::read_and_increment_nonce;
 use crate::public_types::{
-    Identifier, KeyedAccountAuthorization, KeyedAuthorization, KeyedEd25519Authorization, Message,
+    Identifier, KeyedAccountAuthorization, KeyedAuthorization, KeyedEd25519Signature, Message,
     MessageV0, U256,
 };
 use soroban_sdk::serde::Serialize;
@@ -18,12 +18,7 @@ pub enum Domain {
     Unfreeze = 7,
 }
 
-fn check_ed25519_auth(
-    e: &Env,
-    auth: KeyedEd25519Authorization,
-    domain: Domain,
-    parameters: EnvVal,
-) {
+fn check_ed25519_auth(e: &Env, auth: KeyedEd25519Signature, domain: Domain, parameters: EnvVal) {
     let msg = MessageV0 {
         nonce: read_and_increment_nonce(&e, Identifier::Ed25519(auth.public_key.clone())),
         domain: domain as u32,

--- a/src/public_types.rs
+++ b/src/public_types.rs
@@ -10,13 +10,6 @@ pub struct KeyedEd25519Signature {
     pub signature: U512,
 }
 
-#[derive(Clone)]
-#[contracttype]
-pub struct KeyedEd25519Authorization {
-    pub public_key: U256,
-    pub signature: U512,
-}
-
 pub type AccountAuthorization = Vec<KeyedEd25519Signature>;
 
 #[derive(Clone)]
@@ -38,7 +31,7 @@ pub enum Authorization {
 #[contracttype]
 pub enum KeyedAuthorization {
     Contract,
-    Ed25519(KeyedEd25519Authorization),
+    Ed25519(KeyedEd25519Signature),
     Account(KeyedAccountAuthorization),
 }
 

--- a/src/testutils.rs
+++ b/src/testutils.rs
@@ -2,7 +2,7 @@
 
 use crate::cryptography::Domain;
 use crate::public_types::{
-    Authorization, Identifier, KeyedAuthorization, KeyedEd25519Authorization, Message, MessageV0,
+    Authorization, Identifier, KeyedAuthorization, KeyedEd25519Signature, Message, MessageV0,
 };
 use crate::*;
 use ed25519_dalek::Keypair;
@@ -61,7 +61,7 @@ impl Token {
             domain: Domain::Approve as u32,
             parameters: args,
         });
-        let auth = KeyedAuthorization::Ed25519(KeyedEd25519Authorization {
+        let auth = KeyedAuthorization::Ed25519(KeyedEd25519Signature {
             public_key: from.public.to_bytes().into_val(&self.env),
             signature: from.sign(msg).unwrap().into_val(&self.env),
         });
@@ -85,7 +85,7 @@ impl Token {
             domain: Domain::Transfer as u32,
             parameters: args,
         });
-        let auth = KeyedAuthorization::Ed25519(KeyedEd25519Authorization {
+        let auth = KeyedAuthorization::Ed25519(KeyedEd25519Signature {
             public_key: FixedBinary::from_array(&self.env, from.public.to_bytes()),
             signature: from.sign(msg).unwrap().into_val(&self.env),
         });
@@ -108,7 +108,7 @@ impl Token {
             domain: Domain::TransferFrom as u32,
             parameters: args,
         });
-        let auth = KeyedAuthorization::Ed25519(KeyedEd25519Authorization {
+        let auth = KeyedAuthorization::Ed25519(KeyedEd25519Signature {
             public_key: spender.public.to_bytes().into_val(&self.env),
             signature: spender.sign(msg).unwrap().into_val(&self.env),
         });


### PR DESCRIPTION
### What

Remove `KeyedEd25519Authorization`.

### Why

It was the same as `KeyedEd25519Signature` after #20.

### Known limitations

None