### PR TITLE
Expose contractenvmetav0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -537,7 +537,7 @@ dependencies = [
 [[package]]
 name = "soroban-sdk"
 version = "0.0.3"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=ac51d33#ac51d3315ac811dc60059198d3004f7eeda62652"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=53721da#53721da9854506ac6e8aa3cc32babc3f9b826c4a"
 dependencies = [
  "ed25519-dalek",
  "soroban-env-guest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -537,7 +537,7 @@ dependencies = [
 [[package]]
 name = "soroban-sdk"
 version = "0.0.3"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=53721da#53721da9854506ac6e8aa3cc32babc3f9b826c4a"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=d5af365#d5af365c1ac19f7576e63c0ad4e8298f8100875f"
 dependencies = [
  "ed25519-dalek",
  "soroban-env-guest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,6 @@ rand = { version = "0.7.3" }
 [patch.crates-io]
 soroban-sdk = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "d5af365" }
 # soroban-sdk = { path = "../rs-soroban-sdk/sdk" }
+
+[profile.release]
+codegen-units = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,12 @@ testutils = ["soroban-sdk/testutils", "dep:ed25519-dalek"]
 [dependencies]
 ed25519-dalek = { version = "1.0.1", optional = true }
 num-bigint = { version = "0.4", optional = true }
-soroban-sdk = { version = "0.0.3", git = "https://github.com/stellar/rs-soroban-sdk", rev = "ac51d33" }
-# soroban-sdk = { path = "../rs-soroban-sdk/sdk" }
+soroban-sdk = { version = "0.0.3" }
 
 [dev-dependencies]
 soroban-token-contract = { path = ".", features = ["export", "testutils"] }
 rand = { version = "0.7.3" }
+
+[patch.crates-io]
+soroban-sdk = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "ac51d33" }
+# soroban-sdk = { path = "../rs-soroban-sdk/sdk" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,5 +27,5 @@ soroban-token-contract = { path = ".", features = ["export", "testutils"] }
 rand = { version = "0.7.3" }
 
 [patch.crates-io]
-soroban-sdk = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "ac51d33" }
+soroban-sdk = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "d5af365" }
 # soroban-sdk = { path = "../rs-soroban-sdk/sdk" }


### PR DESCRIPTION
### What

Switches to use `[patch.crates-io]`, picks up new SDK changes, and sets `codegen-units = 1`.

### Why

Needed to make WASM runnable.

### Known limitations

This _only_ works with `codegen-units = 1`.