### PR TITLE
Generalize authorization

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -8,6 +8,7 @@ use crate::metadata::{
 };
 use crate::nonce::read_nonce;
 use crate::public_types::{Authorization, Identifier, KeyedAuthorization};
+use crate::storage_types::DataKey;
 use soroban_sdk::{contractimpl, BigInt, Binary, Env, IntoVal};
 
 pub trait TokenTrait {
@@ -62,6 +63,18 @@ pub enum Domain {
     Unfreeze = 7,
 }
 
+pub fn get_nonce_key(auth: &KeyedAuthorization) -> Option<DataKey> {
+    match auth {
+        KeyedAuthorization::Contract => None,
+        KeyedAuthorization::Ed25519(kea) => {
+            Some(DataKey::Nonce(Identifier::Ed25519(kea.public_key.clone())))
+        }
+        KeyedAuthorization::Account(kaa) => {
+            Some(DataKey::Nonce(Identifier::Account(kaa.public_key.clone())))
+        }
+    }
+}
+
 pub struct Token;
 
 #[contractimpl(export_if = "export")]
@@ -78,7 +91,7 @@ impl TokenTrait for Token {
     }
 
     fn nonce(e: Env, id: Identifier) -> BigInt {
-        read_nonce(&e, id)
+        read_nonce(&e, DataKey::Nonce(id))
     }
 
     fn allowance(e: Env, from: Identifier, spender: Identifier) -> BigInt {
@@ -89,9 +102,10 @@ impl TokenTrait for Token {
         let from_id = from.get_identifier(&e);
         check_auth(
             &e,
-            from,
+            &from,
             Domain::Approve as u32,
             (spender.clone(), amount.clone()).into_val(&e),
+            get_nonce_key(&from),
         );
         write_allowance(&e, from_id, spender, amount);
     }
@@ -108,9 +122,10 @@ impl TokenTrait for Token {
         let from_id = from.get_identifier(&e);
         check_auth(
             &e,
-            from,
+            &from,
             Domain::Transfer as u32,
             (to.clone(), amount.clone()).into_val(&e),
+            get_nonce_key(&from),
         );
         spend_balance(&e, from_id, amount.clone());
         receive_balance(&e, to, amount);
@@ -126,9 +141,10 @@ impl TokenTrait for Token {
         let spender_id = spender.get_identifier(&e);
         check_auth(
             &e,
-            spender,
+            &spender,
             Domain::TransferFrom as u32,
             (from.clone(), to.clone(), amount.clone()).into_val(&e),
+            get_nonce_key(&spender),
         );
         spend_allowance(&e, from.clone(), spender_id, amount.clone());
         spend_balance(&e, from, amount.clone());
@@ -139,16 +155,23 @@ impl TokenTrait for Token {
         let auth = to_administrator_authorization(&e, admin);
         check_auth(
             &e,
-            auth,
+            &auth,
             Domain::Burn as u32,
             (from.clone(), amount.clone()).into_val(&e),
+            get_nonce_key(&auth),
         );
         spend_balance(&e, from, amount);
     }
 
     fn freeze(e: Env, admin: Authorization, id: Identifier) {
         let auth = to_administrator_authorization(&e, admin);
-        check_auth(&e, auth, Domain::Freeze as u32, (id.clone(),).into_val(&e));
+        check_auth(
+            &e,
+            &auth,
+            Domain::Freeze as u32,
+            (id.clone(),).into_val(&e),
+            get_nonce_key(&auth),
+        );
         write_state(&e, id, true);
     }
 
@@ -156,9 +179,10 @@ impl TokenTrait for Token {
         let auth = to_administrator_authorization(&e, admin);
         check_auth(
             &e,
-            auth,
+            &auth,
             Domain::Mint as u32,
             (to.clone(), amount.clone()).into_val(&e),
+            get_nonce_key(&auth),
         );
         receive_balance(&e, to, amount);
     }
@@ -167,9 +191,10 @@ impl TokenTrait for Token {
         let auth = to_administrator_authorization(&e, admin);
         check_auth(
             &e,
-            auth,
+            &auth,
             Domain::SetAdministrator as u32,
             (new_admin.clone(),).into_val(&e),
+            get_nonce_key(&auth),
         );
         write_administrator(&e, new_admin);
     }
@@ -178,9 +203,10 @@ impl TokenTrait for Token {
         let auth = to_administrator_authorization(&e, admin);
         check_auth(
             &e,
-            auth,
+            &auth,
             Domain::Unfreeze as u32,
             (id.clone(),).into_val(&e),
+            get_nonce_key(&auth),
         );
         write_state(&e, id, false);
     }

--- a/src/cryptography.rs
+++ b/src/cryptography.rs
@@ -6,22 +6,10 @@ use crate::public_types::{
 use soroban_sdk::serde::Serialize;
 use soroban_sdk::{Account, Env, EnvVal};
 
-#[repr(u32)]
-pub enum Domain {
-    Approve = 0,
-    Transfer = 1,
-    TransferFrom = 2,
-    Burn = 3,
-    Freeze = 4,
-    Mint = 5,
-    SetAdministrator = 6,
-    Unfreeze = 7,
-}
-
-fn check_ed25519_auth(e: &Env, auth: KeyedEd25519Signature, domain: Domain, parameters: EnvVal) {
+fn check_ed25519_auth(e: &Env, auth: KeyedEd25519Signature, domain: u32, parameters: EnvVal) {
     let msg = MessageV0 {
         nonce: read_and_increment_nonce(&e, Identifier::Ed25519(auth.public_key.clone())),
-        domain: domain as u32,
+        domain: domain,
         parameters: parameters.try_into().unwrap(),
     };
     let msg_bin = Message::V0(msg).serialize(e);
@@ -29,17 +17,12 @@ fn check_ed25519_auth(e: &Env, auth: KeyedEd25519Signature, domain: Domain, para
     e.verify_sig_ed25519(auth.public_key.into(), msg_bin, auth.signature.into());
 }
 
-fn check_account_auth(
-    e: &Env,
-    auth: KeyedAccountAuthorization,
-    domain: Domain,
-    parameters: EnvVal,
-) {
+fn check_account_auth(e: &Env, auth: KeyedAccountAuthorization, domain: u32, parameters: EnvVal) {
     let acc = Account::from_public_key(&auth.public_key).unwrap();
 
     let msg = MessageV0 {
         nonce: read_and_increment_nonce(&e, Identifier::Account(auth.public_key)),
-        domain: domain as u32,
+        domain: domain,
         parameters: parameters.try_into().unwrap(),
     };
     let msg_bin = Message::V0(msg).serialize(e);
@@ -73,7 +56,7 @@ fn check_account_auth(
     }
 }
 
-pub fn check_auth(e: &Env, auth: KeyedAuthorization, domain: Domain, parameters: EnvVal) {
+pub fn check_auth(e: &Env, auth: KeyedAuthorization, domain: u32, parameters: EnvVal) {
     match auth {
         KeyedAuthorization::Contract => {
             e.get_invoking_contract();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,14 +8,12 @@ mod admin;
 mod allowance;
 mod balance;
 mod contract;
-mod cryptography;
+pub mod cryptography;
 mod metadata;
 mod nonce;
 pub mod public_types;
 mod storage_types;
 pub mod testutils;
-
-pub use cryptography::Domain;
 
 pub use crate::contract::allowance::invoke as allowance;
 pub use crate::contract::approve::invoke as approve;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ mod balance;
 mod contract;
 pub mod cryptography;
 mod metadata;
-mod nonce;
+pub mod nonce;
 pub mod public_types;
 mod storage_types;
 pub mod testutils;

--- a/src/nonce.rs
+++ b/src/nonce.rs
@@ -1,20 +1,24 @@
-use crate::public_types::Identifier;
-use crate::storage_types::DataKey;
-use soroban_sdk::{BigInt, Env};
+use soroban_sdk::{BigInt, Env, IntoVal, RawVal};
 
-pub fn read_nonce(e: &Env, id: Identifier) -> BigInt {
-    let key = DataKey::Nonce(id);
-    if let Some(nonce) = e.contract_data().get(key) {
+use crate::cryptography::ContractDataKey;
+
+pub fn read_nonce<T>(e: &Env, nonce_key: T) -> BigInt
+where
+    T: IntoVal<Env, RawVal>,
+{
+    if let Some(nonce) = e.contract_data().get(nonce_key) {
         nonce.unwrap()
     } else {
         BigInt::zero(e)
     }
 }
 
-pub fn read_and_increment_nonce(e: &Env, id: Identifier) -> BigInt {
-    let key = DataKey::Nonce(id.clone());
-    let nonce = read_nonce(e, id);
+pub fn read_and_increment_nonce<T>(e: &Env, nonce_key: T) -> BigInt
+where
+    T: IntoVal<Env, RawVal> + ContractDataKey,
+{
+    let nonce = read_nonce(e, nonce_key.clone());
     e.contract_data()
-        .set(key, nonce.clone() + BigInt::from_u32(e, 1));
+        .set(nonce_key, nonce.clone() + BigInt::from_u32(e, 1));
     nonce
 }

--- a/src/storage_types.rs
+++ b/src/storage_types.rs
@@ -1,4 +1,4 @@
-use crate::public_types::Identifier;
+use crate::{cryptography::ContractDataKey, public_types::Identifier};
 use soroban_sdk::contracttype;
 
 #[derive(Clone)]
@@ -20,3 +20,5 @@ pub enum DataKey {
     Name,
     Symbol,
 }
+
+impl ContractDataKey for DataKey {}

--- a/src/testutils.rs
+++ b/src/testutils.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "testutils")]
 
-use crate::cryptography::Domain;
+use crate::contract::Domain;
 use crate::public_types::{
     Authorization, Identifier, KeyedAuthorization, KeyedEd25519Signature, Message, MessageV0,
 };


### PR DESCRIPTION
Resolves #31.

Generalizes authorization so contracts don't keep copying the same authorization code. The next step would be to move the authorization helpers into the SDK. There's more we can generalize like the admin module, but wanted to get feedback on this change first because passing around DataKeys may be more error prone than we'd like.

Here is the change to the single offer contract that uses this PR - 
https://github.com/sisuresh/rs-stellar-liqpool-example/commit/eaddada55bb53dd9f6f617b70e6940212c541f5a.

