### PR TITLE
Fix ci complete job (again)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,10 +11,12 @@ env:
 jobs:
 
   complete:
+    if: always()
     needs: [fmt, build-and-test]
     runs-on: ubuntu-latest
     steps:
-    - run: exit 0
+    - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+      run: exit 1
 
   fmt:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### What
Change ci complete job to always run and explicitly check the results of the depended jobs.

### Why
In #76 I changed the way the complete job worked to catch cancelled jobs, but apparently I made the situation worse and caused failing jobs to be ignored, because the complete job was being skipped and skipped jobs are interpreted as success by GitHub's required checks.