### PR TITLE
Add deprecated notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 **The code in this repository is deprecated.**
 
-Looking for the Soroban built-in token contract, see https://soroban.stellar.org/docs/built-in-contracts/token.
+For more information about the Soroban built-in token contract, see https://soroban.stellar.org/docs/built-in-contracts/token.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # soroban-token-contract
 
-[Standard token implementation](https://soroban.stellar.org/docs/standard-contracts/token-contract/) for Soroban
+**The code in this repository is deprecated.**
 
-WARNING: This implementation has not been tested or audited. It is likely to
-have significant errors and security vulnerabilities. It should not be relied
-on for any purpose.
+Looking for the Soroban built-in token contract, see https://soroban.stellar.org/docs/built-in-contracts/token.


### PR DESCRIPTION
### What

Add deprecated notice.

### Why

@sisuresh and I discussed doing this sometime ago and we forgot. There's an open https://github.com/stellar/ops/issues/1836 ticket to archive the repo. In the meantime while we wait for it to be archived lets make it clear in the README that this is not the native/builtin token anymore.

### Known limitations

[TODO or N/A]
